### PR TITLE
Added basic SimulStream support that is provided in addition to existing SimulEval evaluation structure

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "simulstream"]
+	path = simulstream
+	url = https://github.com/hlt-mt/simulstream.git

--- a/README.md
+++ b/README.md
@@ -5,10 +5,12 @@
 2. Setup tools (see [tools/README.md](tools/README.md))
 3. Setup data (see [data/README.md](data/README.md))
 
+This year, we will use SimulStream (see https://github.com/hlt-mt/simulstream) for test set evaluations. Example scripts are provided and it can be accessed as a submodule of this repository. Installation for SimulStream may need to be done separately.
+
 ## Experiments
 
 ### ACL 60/60: English-to-German
 See [experiments/acl6060_dev/de/fixed_segmenter/README.md](experiments/acl6060_dev/de/fixed_segmenter/README.md)
 
-### MCIF: English-to-German
+### MCIF: English-to-Italian
 See [experiments/mcif/it/fixed_segmenter/README.md](experiments/mcif/it/fixed_segmenter/README.md)

--- a/data/mcif/prepare_mcif.py
+++ b/data/mcif/prepare_mcif.py
@@ -70,7 +70,8 @@ if __name__ == "__main__":
          open(os.path.join(save_dir, "tgt.txt"), "w") as tgt_f, \
          open(os.path.join(save_dir, "tgt_segments.txt"), "w") as tgt_seg_f, \
          open(os.path.join(save_dir, "transcript.txt"), "w") as transcript_f, \
-         open(os.path.join(save_dir, "transcript_segments.txt"), "w") as transcript_seg_f:
+         open(os.path.join(save_dir, "transcript_segments.txt"), "w") as transcript_seg_f, \
+         open(os.path.join(wav_dir, "wav_list.txt") as wav_list_f:
 
         for task_num, doc in docs:
             docid = doc['docid']
@@ -82,6 +83,8 @@ if __name__ == "__main__":
 
             src_f.write(f"{doc_wav_path}\n")
 
+            wav_list_f.write(f"{docid}.wav")
+
             tgt_f.write(" ".join(tgt_segs).replace("\n", " ") + "\n")
             for seg in tgt_segs:
                 tgt_seg_f.write(f"{seg.strip()}\n")
@@ -90,4 +93,4 @@ if __name__ == "__main__":
             for seg in src_segs:
                 transcript_seg_f.write(f"{seg.strip()}\n")
 
-    print(f"Wrote outputs for {len(docs)} TRANS tasks to {save_dir}/")
+    print(f"Wrote outputs for {len(docs)} TRANS tasks to {save_dir}/ and wav_list.txt to {wav_dir} for SimulStream use")

--- a/experiments/mcif/it/cascade/README.md
+++ b/experiments/mcif/it/cascade/README.md
@@ -49,3 +49,8 @@ Following the previous tuning, we also sweep the minimum segment length (in numb
 ## Final Results
 
 Pending, should be updated with these soon.
+
+
+## SimulStream Usage Script
+
+In addition to the results seen here, we also provide an example of a script that can be run with SimulStream in this directory. It should be a drop-in replacement for the `run_simuleval.sh` script and may be used instead.

--- a/experiments/mcif/it/cascade/run_simulstream.sh
+++ b/experiments/mcif/it/cascade/run_simulstream.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+export PYTHONPATH="${REPO_ROOT_PATH}"
+export LD_LIBRARY_PATH="${REPO_ROOT_PATH}/iwslt25_env/lib/python3.10/site-packages/nvidia/cudnn/lib"
+
+segment_length=$1
+step_length=$2
+translation_la_policy=$3
+transcript_context=${4}
+translation_max_input_length_soft=${5}
+
+output_dir=${6}/segment-length_${segment_length}_step-length_${step_length}_translation-la-policy_${translation_la_policy}_transcript-context_${transcript_context}_translation-max-input-length-soft_${translation_max_input_length_soft}
+
+if [[ -f $output_dir/scores.tsv ]]
+then
+    echo $output_dir/scores.tsv exists - exiting
+    exit 0
+fi
+
+mkdir -p $output_dir
+
+# Creates necessary config YAML dynamically
+# If the agent.py or underlying class is updated, the default arguments may need to be updated
+cat > simulstream_wrapper_for_simuleval_config.yaml <<EOF
+type: "simulstream.server.speech_processors.simuleval_wrapper.SimulEvalWrapper"
+simuleval_agent: "agent.CascadeAgentWitFixedLengthSegmenter"
+latency_unit: word
+speech_chunk_size: 1.0  # seconds
+detokenizer_type: "simuleval"
+
+source_segment_size: 100
+step_length: ${step_length}
+whisper_model: "large-v2"
+device: "cuda"
+translation_language: "it"
+segment_length: ${segment_length}
+translation_la_policy: ${translation_la_policy}
+transcript_context: ${transcript_context}
+translation_max_input_length_soft: ${translation_max_input_length_soft}
+
+# need to include a bunch of previously default arguments
+whisper_language: "en"
+translation_model: "facebook/m2m100_418M"
+translation_max_input_length_hard: 40
+whisper_task: "transcribe"
+EOF
+
+simulstream_inference --speech-processor-config simulstream_wrapper_for_simuleval_config.yaml \
+    --wav-list-file ${REPO_ROOT_PATH}/data/MCIF_AUDIO/wav_list.txt \
+    --tgt-lang it --src-lang en --metrics-log-file ${output_dir}/metrics.jsonl
+
+simulstream_score_quality --scorer sacrebleu \
+    --eval-config simulstream_wrapper_for_simuleval_config.yaml \
+    --log-file ${output_dir}/metrics.jsonl \
+    --references ${REPO_ROOT_PATH}/data/it/tgt.it
+
+simulstream_stats --eval-config simulstream_wrapper_for_simuleval_config.yaml \
+    --log-file ${output_dir}/metrics.jsonl

--- a/experiments/mcif/it/fixed_segmenter/README.md
+++ b/experiments/mcif/it/fixed_segmenter/README.md
@@ -49,3 +49,8 @@ bash eval.sh
 | 27.54 | 3508       | 4664          |
 | 27.78 | 3741       | 4846          |
 | 38.91 | 3912       | 5034          |
+
+
+## SimulStream Usage Script
+
+In addition to the results seen here, we also provide an example of a script that can be run with SimulStream in this directory. It should be a drop-in replacement for the `run_simuleval.sh` script and may be used instead.

--- a/experiments/mcif/it/fixed_segmenter/run_simulstream.sh
+++ b/experiments/mcif/it/fixed_segmenter/run_simulstream.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+export PYTHONPATH="${REPO_ROOT_PATH}"
+export LD_LIBRARY_PATH="${REPO_ROOT_PATH}/iwslt25_env/lib/python3.10/site-packages/nvidia/cudnn/lib"
+
+segment_length=$1
+step_length=$2
+
+output_dir=$3/segment-length_${segment_length}_step-length_${step_length}
+
+if [[ -f $output_dir/scores.tsv ]]
+then
+    echo $output_dir/scores.tsv exists - exiting
+    exit 0
+fi
+
+mkdir -p $output_dir
+
+# Creates necessary config YAML dynamically
+cat > simulstream_wrapper_for_simuleval_config.yaml <<EOF
+type: "simulstream.server.speech_processors.simuleval_wrapper.SimulEvalWrapper"
+simuleval_agent: "agent.SeamlessM4TAgentWithFixedSegmenter"
+latency_unit: word
+speech_chunk_size: 1.0  # seconds
+detokenizer_type: "simuleval"
+
+source_segment_size: 250
+step_length: ${step_length}
+device: "cuda"
+seamless_m4t_tgt_lang: "ita"
+segment_length: ${segment_length}
+
+# need to include default arguments
+seamless_m4t_model: "facebook/seamless-m4t-v2-large"
+eval_latency_unit: "word"
+EOF
+
+simulstream_inference --speech-processor-config simulstream_wrapper_for_simuleval_config.yaml \
+    --wav-list-file ${REPO_ROOT_PATH}/data/MCIF_AUDIO/wav_list.txt \
+    --tgt-lang it --src-lang en --metrics-log-file ${output_dir}/metrics.jsonl
+
+simulstream_score_quality --scorer sacrebleu \
+    --eval-config simulstream_wrapper_for_simuleval_config.yaml \
+    --log-file ${output_dir}/metrics.jsonl \
+    --references ${REPO_ROOT_PATH}/data/it/tgt.it
+
+simulstream_stats --eval-config simulstream_wrapper_for_simuleval_config.yaml \
+    --log-file ${output_dir}/metrics.jsonl

--- a/experiments/mcif/it/vad_segmenter/README.md
+++ b/experiments/mcif/it/vad_segmenter/README.md
@@ -43,3 +43,8 @@ bash eval.sh
 | 36.17 | 3447       | 4536         |
 | 36.47 | 3833       | 4900         |
 | 36.26 | 4130       | 5232         |
+
+
+## SimulStream Usage Script
+
+In addition to the results seen here, we also provide an example of a script that can be run with SimulStream in this directory. It should be a drop-in replacement for the `run_simuleval.sh` script and may be used instead.

--- a/experiments/mcif/it/vad_segmenter/run_simulstream.sh
+++ b/experiments/mcif/it/vad_segmenter/run_simulstream.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+export PYTHONPATH="${REPO_ROOT_PATH}:./"
+export LD_LIBRARY_PATH="${REPO_ROOT_PATH}/iwslt25_env/lib/python3.10/site-packages/nvidia/cudnn/lib"
+
+max_unvoiced_length=$1
+voice_threshold=$2
+step_length=$3
+
+output_dir=${4}/pause_${max_unvoiced_length}_threshold_${voice_threshold}_step-length_${step_length}
+
+if [[ -f $output_dir/scores.tsv ]]
+then
+    echo $output_dir/scores.tsv exists - exiting
+    exit 0
+fi
+
+mkdir -p $output_dir
+
+# Creates necessary config YAML dynamically
+cat > simulstream_wrapper_for_simuleval_config.yaml <<EOF
+type: "simulstream.server.speech_processors.simuleval_wrapper.SimulEvalWrapper"
+simuleval_agent: "agent.SeamlessM4TAgentWithVADSegmenter"
+latency_unit: word
+speech_chunk_size: 1.0  # seconds
+detokenizer_type: "simuleval"
+
+source_segment_size: 250
+step_length: ${step_length}
+device: "cuda"
+seamless_m4t_tgt_lang: "ita"
+max_unvoiced_length: ${max_unvoiced_length}
+voice_threshold: ${voice_threshold}
+min_segment_length: 2.0
+max_segment_length: 20.0
+window_size_samples: 512
+sample_rate: 16000
+dump_audio_path: null
+
+# need to include default arguments
+seamless_m4t_model: "facebook/seamless-m4t-v2-large"
+eval_latency_unit: "word"
+EOF
+
+simulstream_inference --speech-processor-config simulstream_wrapper_for_simuleval_config.yaml \
+    --wav-list-file ${REPO_ROOT_PATH}/data/MCIF_AUDIO/wav_list.txt \
+    --tgt-lang it --src-lang en --metrics-log-file ${output_dir}/metrics.jsonl
+
+simulstream_score_quality --scorer sacrebleu \
+    --eval-config simulstream_wrapper_for_simuleval_config.yaml \
+    --log-file ${output_dir}/metrics.jsonl \
+    --references ${REPO_ROOT_PATH}/data/it/tgt.it
+
+simulstream_stats --eval-config simulstream_wrapper_for_simuleval_config.yaml \
+    --log-file ${output_dir}/metrics.jsonl


### PR DESCRIPTION
This PR adds some extra scripts and a submodule for SimulStream support. For en-it, this support is extraneous. It will be required for en-zh baselines. 

Basically, the script creates a YAML config in the format that SimulStream expects and uses the SimulEval agent wrapper provided by SimulStream to do so. Some default args have to be specified in the config, as they don't seem to work out of the box with argparse defaults.

In addition to the added scripts, the MCIF preparation script is modified to produce a wav_list text file in the format and location expected by SimulStream (this is based on empirical tests and a quick examination of the wav reader in that repo).